### PR TITLE
Fix to set custom username, passwd, and hostname to each Api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ api = F5::Icontrol::API.new
 response = api.LocalLB.Pool.get_list
 ```
 
+or You can configure per api client.
+
+```Ruby
+api = F5::Icontrol::API.new(
+  nil, # This first argument `nil` is required.
+  {
+    host: "hostname.of.bigip",
+    username: "username",
+    password: "password",
+  }
+)
+response = api.LocalLB.Pool.get_list
+```
+
 See specs subdir for more examples, especially as it pertains to passing parameters.
 
 ## CLI

--- a/lib/f5/icontrol/api.rb
+++ b/lib/f5/icontrol/api.rb
@@ -3,10 +3,11 @@ module F5
     class API
       attr_accessor :api_path
 
-      def initialize(api_path = nil)
-        @username="a"
-        @password="b"
-        @hostname="xxx"
+      def initialize(api_path = nil, params = {})
+        @params = params.dup
+        @username = params[:username]
+        @password = params[:password]
+        @hostname = params[:host] || params[:hostname]
         @client_cache = {}
         @api_path = api_path
       end
@@ -24,7 +25,7 @@ module F5
             response.to_hash[response_key][:return]
 
         elsif supported_path? append_path(method)
-          self.class.new append_path(method)
+          self.class.new append_path(method), @params
         else
           raise NameError, "#{method} is not supported by #{@api_path}"
         end
@@ -57,9 +58,9 @@ module F5
         endpoint = '/iControl/iControlPortal.cgi'
         @client_cache[@api_path] ||=
           Savon.client(wsdl: "#{wsdl_path}#{@api_path}.wsdl",
-                       endpoint: "https://#{F5::Icontrol.configuration.host}#{endpoint}",
+                       endpoint: "https://#{@hostname || F5::Icontrol.configuration.host}#{endpoint}",
                        ssl_verify_mode: :none,
-                       basic_auth: [F5::Icontrol.configuration.username, F5::Icontrol.configuration.password],
+                       basic_auth: [@username || F5::Icontrol.configuration.username, @password || F5::Icontrol.configuration.password],
                        #log: true,
                        #logger: Logger.new(STDOUT),
                        #pretty_print_xml: true,


### PR DESCRIPTION
I would like to run multiple api clients in threads to communicate with multiple BIGIPs in the same timing. So I want this feature to set these params per instance.