### PR TITLE
Set the ratio of pool members

### DIFF
--- a/f5-icontrol.gemspec
+++ b/f5-icontrol.gemspec
@@ -21,10 +21,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "savon", "~> 2.0"
   spec.add_dependency "thor"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "awesome_print"
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 end

--- a/lib/f5/cli/application.rb
+++ b/lib/f5/cli/application.rb
@@ -331,15 +331,6 @@ module F5
 
       end
 
-      desc "getratio POOL", "Gets the dynamic ratio of the given pool"
-      def getratio(pool)
-        response = client.LocalLB.Pool.get_member_ratio(
-          pool_names: { item: [ pool ] },
-          members: { item: [ pool_members(pool) ] }
-        )
-
-      end
-
       private
 
       def address_port_list_from_pool(pool, members)

--- a/lib/f5/cli/application.rb
+++ b/lib/f5/cli/application.rb
@@ -210,8 +210,8 @@ module F5
         response = client.Networking.VLAN.create_v2(
           vlans: { item: [ name ] },
           vlan_ids: { item: [ vid ] },
-          members: {  item: [ item: memberdata ] },
-          failsafe_states: {  item: [ 'STATE_DISABLED' ] },
+          members: { item: [ item: memberdata ] },
+          failsafe_states: { item: [ 'STATE_DISABLED' ] },
           timeouts: { item: [ 100 ] } #???
         )
         puts response
@@ -286,13 +286,13 @@ module F5
         response = client.LocalLB.Pool.set_member_session_enabled_state(
           pool_names: { item: [ pool ] },
           members: { item: [ set ] },
-          session_states: {  item: [ set.map { "STATE_ENABLED" } ] }
+          session_states: { item: [ set.map { "STATE_ENABLED" } ] }
         )
 
         response = client.LocalLB.Pool.set_member_monitor_state(
           pool_names: { item: [ pool ] },
           members: { item: [ set ] },
-          monitor_states: {  item: [ set.map { "STATE_ENABLED" } ] }
+          monitor_states: { item: [ set.map { "STATE_ENABLED" } ] }
         )
 
       end
@@ -307,19 +307,47 @@ module F5
         response = client.LocalLB.Pool.set_member_session_enabled_state(
           pool_names: { item: [ pool ] },
           members: { item: [ set ] },
-          session_states: {  item: [ set.map { "STATE_DISABLED" } ] }
+          session_states: { item: [ set.map { "STATE_DISABLED" } ] }
         )
 
         if options[:force]
           response = client.LocalLB.Pool.set_member_monitor_state(
             pool_names: { item: [ pool ] },
             members: { item: [ set ] },
-            monitor_states: {  item: [ set.map { "STATE_DISABLED" } ] }
+            monitor_states: { item: [ set.map { "STATE_DISABLED" } ] }
           )
         end
       end
 
+      desc "setratio --ratio RATIO POOL MEMBERS", "Sets the dynamic ratio of the given members to RATIO"
+      method_option :ratio, type: :numeric, desc: "The node's new dynamic ratio", required: true
+      def setratio(pool, *members)
+        set = address_port_list_from_pool(pool, members)
+        response = client.LocalLB.Pool.set_member_ratio(
+          pool_names: { item: [ pool ] },
+          members: { item: [ set ] },
+          ratios: { item: [ set.map { options[:ratio] } ] }
+        )
+
+      end
+
+      desc "getratio POOL", "Gets the dynamic ratio of the given pool"
+      def getratio(pool)
+        response = client.LocalLB.Pool.get_member_ratio(
+          pool_names: { item: [ pool ] },
+          members: { item: [ pool_members(pool) ] }
+        )
+
+      end
+
       private
+
+      def address_port_list_from_pool(pool, members)
+        pool_members(pool).select do |m|
+          members.include?(m[:address]) || members.include?(m[:address].gsub(%r{^/Common/}, ''))
+        end
+      end
+
       def pool_members(pool)
         response = client.LocalLB.Pool.get_member_v2(pool_names: { item: [ pool ] } )
 

--- a/lib/f5/cli/application.rb
+++ b/lib/f5/cli/application.rb
@@ -298,7 +298,7 @@ module F5
       end
 
       desc "disable POOL MEMBERS", "Disables the given members"
-      method_option :force, default: false, desc: "Forces the node offline (only active connections allowed)"
+      method_option :force, default: false, type: :boolean, desc: "Forces the node offline (only active connections allowed)"
       def disable(pool, *members)
         set = pool_members(pool).select do |m|
           members.include? m[:address]


### PR DESCRIPTION
Ratios are helpful to weight traffic differently should you have different hardware in the pool or want to do load testing