### PR TITLE
Fix iControl Enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ response = api.LocalLB.Pool.get_list
 
 See specs subdir for more examples, especially as it pertains to passing parameters.
 
+## Logging
+
+This gem uses the [`Savon`](http://savonrb.com/) client to wrap the SOAP endpoints,
+and it is sometimes useful to be able to see the SOAP request and response XML.
+
+You can pass in a few options during configuration of the api client
+which are forwarded to the internal `Savon` client:
+
+```Ruby
+api = F5::Icontrol::API.new(
+    host: "hostname.of.bigip",
+    username: "username",
+    password: "password",
+
+    # Savon logging options
+    enable_logging: true,   # defaults to: false
+    log_level: :debug,      # defaults to: debug
+    pretty_print_xml: true, # defaults to: true
+)
+
+```
+
 ## CLI
 
 There's a command line version that's still being roughed out. You'll need a `~/.f5.yml` file containing your login information:

--- a/lib/f5/icontrol/api.rb
+++ b/lib/f5/icontrol/api.rb
@@ -8,6 +8,9 @@ module F5
         @username = params[:username]
         @password = params[:password]
         @hostname = params[:host] || params[:hostname]
+        @enable_logging = params[:enable_logging] || false
+        @log_level = params[:log_level] ? params[:log_level].to_sym : :debug
+        @pretty_print_xml = params[:pretty_print_xml] || true
         @client_cache = {}
         @api_path = api_path
       end
@@ -61,10 +64,10 @@ module F5
                        endpoint: "https://#{@hostname || F5::Icontrol.configuration.host}#{endpoint}",
                        ssl_verify_mode: :none,
                        basic_auth: [@username || F5::Icontrol.configuration.username, @password || F5::Icontrol.configuration.password],
-                       #log: true,
-                       #logger: Logger.new(STDOUT),
-                       #pretty_print_xml: true,
-                       #log_level: :debug,
+                       log: @enable_logging,
+                       logger: Logger.new(STDOUT),
+                       pretty_print_xml: @pretty_print_xml,
+                       log_level: @log_level,
                        namespace: "urn:iControl:#{api_namespace}",
                        convert_request_keys_to: :none
                       )

--- a/lib/f5/icontrol/common/enabled_state.rb
+++ b/lib/f5/icontrol/common/enabled_state.rb
@@ -1,0 +1,12 @@
+require 'f5/icontrol/common/enum_item'
+
+module F5
+  module Icontrol
+    module Common
+      module EnabledState
+        STATE_DISABLED = EnumItem.new('STATE_DISABLED', 0)
+        STATE_ENABLED  = EnumItem.new('STATE_ENABLED', 1)
+      end
+    end
+  end
+end

--- a/lib/f5/icontrol/common/enum_item.rb
+++ b/lib/f5/icontrol/common/enum_item.rb
@@ -1,0 +1,23 @@
+# This is a helper type to encapsulate iControl
+# enumerations in a way which easily gives us
+# access to the member as well as the value,
+# since the SOAP API and the Savon serializers
+# seem to use the string version of the member
+# name rather than the value.
+#
+# Additional iControl enumerations can be generated
+# using nimbletest.com/live with '\t' as a column
+# separator and the following substitution pattern:
+#
+# # $2
+# $0 = EnumItem.new('$0', '$1')
+#
+EnumItem = Struct.new(:member, :value) do
+  def to_s
+    self.member
+  end
+
+  def to_i
+    self.value
+  end
+end

--- a/lib/f5/icontrol/locallb/availability_status.rb
+++ b/lib/f5/icontrol/locallb/availability_status.rb
@@ -1,3 +1,5 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
@@ -5,26 +7,22 @@ module F5
       # A list of possible values for an object's availability status.
       module AvailabilityStatus
         # Error scenario.
-        AVAILABILITY_STATUS_NONE	= 0
+        AVAILABILITY_STATUS_NONE = EnumItem.new('AVAILABILITY_STATUS_NONE', '0')
 
         # The object is available in some capacity.
-        AVAILABILITY_STATUS_GREEN	= 1
+        AVAILABILITY_STATUS_GREEN = EnumItem.new('AVAILABILITY_STATUS_GREEN', '1')
 
-        # The object is not available at the current
-        # moment, but may become available again even
-        # without user intervention.
-        AVAILABILITY_STATUS_YELLOW	= 2
+        # The object is not available at the current moment, but may become available again even without user intervention.
+        AVAILABILITY_STATUS_YELLOW = EnumItem.new('AVAILABILITY_STATUS_YELLOW', '2')
 
-        # The object is not available, and will require
-        # user intervention to make this object available
-        # again.
-        AVAILABILITY_STATUS_RED	= 3
+        # The object is not available, and will require user intervention to make this object available again.
+        AVAILABILITY_STATUS_RED = EnumItem.new('AVAILABILITY_STATUS_RED', '3')
 
         # The object's availability status is unknown.
-        AVAILABILITY_STATUS_BLUE	= 4
+        AVAILABILITY_STATUS_BLUE = EnumItem.new('AVAILABILITY_STATUS_BLUE', '4')
 
         # The object's is unlicensed.
-        AVAILABILITY_STATUS_GRAY	= 5
+        AVAILABILITY_STATUS_GRAY = EnumItem.new('AVAILABILITY_STATUS_GRAY', '5')
       end
     end
   end

--- a/lib/f5/icontrol/locallb/client_ssl_certificate_mode.rb
+++ b/lib/f5/icontrol/locallb/client_ssl_certificate_mode.rb
@@ -1,17 +1,22 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
-      # https://devcentral.f5.com/wiki/iControl.LocalLB__ProfileContextType.ashx
-      # A list of profile context types.
-      module ProfileContextType
-        # Profile applies to both client and server sides.
-        PROFILE_CONTEXT_TYPE_ALL = 0
+      # https://devcentral.f5.com/wiki/iControl.LocalLB__ClientSSLCertificateMode.ashx
+      # A list of client-side SSL certificate modes.
+      module ClientSSLCertificateMode
+        # The client certificate is requested.
+        CLIENTSSL_CERTIFICATE_MODE_REQUEST = EnumItem.new('CLIENTSSL_CERTIFICATE_MODE_REQUEST', '0')
 
-        # Profile applies to the client side only.
-        PROFILE_CONTEXT_TYPE_CLIENT = 1
+        # The client certificate is required.
+        CLIENTSSL_CERTIFICATE_MODE_REQUIRE = EnumItem.new('CLIENTSSL_CERTIFICATE_MODE_REQUIRE', '1')
 
-        # Profile applies to the server side only.
-        PROFILE_CONTEXT_TYPE_SERVER = 2
+        # The client certificate is ignored.
+        CLIENTSSL_CERTIFICATE_MODE_IGNORE = EnumItem.new('CLIENTSSL_CERTIFICATE_MODE_IGNORE', '2')
+
+        # The client certificate processing is auto. As of version 11.0.0, certificate mode AUTO is equivalent to IGNORE.
+        CLIENTSSL_CERTIFICATE_MODE_AUTO = EnumItem.new('CLIENTSSL_CERTIFICATE_MODE_AUTO', '3')
       end
     end
   end

--- a/lib/f5/icontrol/locallb/enabled_status.rb
+++ b/lib/f5/icontrol/locallb/enabled_status.rb
@@ -1,3 +1,5 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
@@ -5,23 +7,16 @@ module F5
       # A list of possible values for enabled status.
       module EnabledStatus
         # Error scenario.
-        ENABLED_STATUS_NONE = 0
+        ENABLED_STATUS_NONE = EnumItem.new('ENABLED_STATUS_NONE', '0')
 
-        #	The object is active when in Green
-        # availability status. It may or may
-        # not be active when in Blue
-        # availability status.
-        ENABLED_STATUS_ENABLED = 1
+        # The object is active when in Green availability status. It may or may not be active when in Blue availability status.
+        ENABLED_STATUS_ENABLED = EnumItem.new('ENABLED_STATUS_ENABLED', '1')
 
-        #	The object is inactive regardless
-        # of availability status.
-        ENABLED_STATUS_DISABLED	= 2
+        # The object is inactive regardless of availability status.
+        ENABLED_STATUS_DISABLED = EnumItem.new('ENABLED_STATUS_DISABLED', '2')
 
-        #	The object is inactive regardless of
-        # availability status because its parent
-        # has been disabled, but the object
-        # itself is still enabled.
-        ENABLED_STATUS_DISABLED_BY_PARENT	= 3
+        # The object is inactive regardless of availability status because its parent has been disabled, but the object itself is still enabled.
+        ENABLED_STATUS_DISABLED_BY_PARENT = EnumItem.new('ENABLED_STATUS_DISABLED_BY_PARENT', '3')
       end
     end
   end

--- a/lib/f5/icontrol/locallb/profile_context_type.rb
+++ b/lib/f5/icontrol/locallb/profile_context_type.rb
@@ -1,3 +1,5 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
@@ -5,13 +7,13 @@ module F5
       # A list of profile context types.
       module ProfileContextType
         # Profile applies to both client and server sides.
-        PROFILE_CONTEXT_TYPE_ALL = 0
+        PROFILE_CONTEXT_TYPE_ALL = EnumItem.new('PROFILE_CONTEXT_TYPE_ALL', '0')
 
         # Profile applies to the client side only.
-        PROFILE_CONTEXT_TYPE_CLIENT = 1
+        PROFILE_CONTEXT_TYPE_CLIENT = EnumItem.new('PROFILE_CONTEXT_TYPE_CLIENT', '1')
 
         # Profile applies to the server side only.
-        PROFILE_CONTEXT_TYPE_SERVER = 2
+        PROFILE_CONTEXT_TYPE_SERVER = EnumItem.new('PROFILE_CONTEXT_TYPE_SERVER', '2')
       end
     end
   end

--- a/lib/f5/icontrol/locallb/profile_type.rb
+++ b/lib/f5/icontrol/locallb/profile_type.rb
@@ -1,3 +1,5 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
@@ -5,82 +7,82 @@ module F5
       # A list of profile types.
       module ProfileType
         # The TCP profile.
-        PROFILE_TYPE_TCP = 0
+        PROFILE_TYPE_TCP = EnumItem.new('PROFILE_TYPE_TCP', '0')
 
         # The UDP profile.
-        PROFILE_TYPE_UDP = 1
+        PROFILE_TYPE_UDP = EnumItem.new('PROFILE_TYPE_UDP', '1')
 
         # The FTP profile.
-        PROFILE_TYPE_FTP = 2
+        PROFILE_TYPE_FTP = EnumItem.new('PROFILE_TYPE_FTP', '2')
 
         # The L4 translation profile.
-        PROFILE_TYPE_FAST_L4 = 3
+        PROFILE_TYPE_FAST_L4 = EnumItem.new('PROFILE_TYPE_FAST_L4', '3')
 
         # The HTTP profile.
-        PROFILE_TYPE_HTTP = 4
+        PROFILE_TYPE_HTTP = EnumItem.new('PROFILE_TYPE_HTTP', '4')
 
         # The server-side SSL profile.
-        PROFILE_TYPE_SERVER_SSL = 5
+        PROFILE_TYPE_SERVER_SSL = EnumItem.new('PROFILE_TYPE_SERVER_SSL', '5')
 
         # The client-side SSL profile.
-        PROFILE_TYPE_CLIENT_SSL = 6
+        PROFILE_TYPE_CLIENT_SSL = EnumItem.new('PROFILE_TYPE_CLIENT_SSL', '6')
 
         # The authorization profile.
-        PROFILE_TYPE_AUTH = 7
+        PROFILE_TYPE_AUTH = EnumItem.new('PROFILE_TYPE_AUTH', '7')
 
         # The persistence profile.
-        PROFILE_TYPE_PERSISTENCE = 8
+        PROFILE_TYPE_PERSISTENCE = EnumItem.new('PROFILE_TYPE_PERSISTENCE', '8')
 
         # The connection pool profile.
-        PROFILE_TYPE_CONNECTION_POOL = 9
+        PROFILE_TYPE_CONNECTION_POOL = EnumItem.new('PROFILE_TYPE_CONNECTION_POOL', '9')
 
         # The stream profile.
-        PROFILE_TYPE_STREAM = 10
+        PROFILE_TYPE_STREAM = EnumItem.new('PROFILE_TYPE_STREAM', '10')
 
         # The XML profile.
-        PROFILE_TYPE_XML = 11
+        PROFILE_TYPE_XML = EnumItem.new('PROFILE_TYPE_XML', '11')
 
         # The FastHTTP profile.
-        PROFILE_TYPE_FAST_HTTP = 12
+        PROFILE_TYPE_FAST_HTTP = EnumItem.new('PROFILE_TYPE_FAST_HTTP', '12')
 
         # The IIOP profile.
-        PROFILE_TYPE_IIOP = 13
+        PROFILE_TYPE_IIOP = EnumItem.new('PROFILE_TYPE_IIOP', '13')
 
         # The RTSP profile.
-        PROFILE_TYPE_RTSP = 14
+        PROFILE_TYPE_RTSP = EnumItem.new('PROFILE_TYPE_RTSP', '14')
 
         # The STATISTICS profile.
-        PROFILE_TYPE_STATISTICS = 15
+        PROFILE_TYPE_STATISTICS = EnumItem.new('PROFILE_TYPE_STATISTICS', '15')
 
         # The HTTP class profile.
-        PROFILE_TYPE_HTTPCLASS = 16
+        PROFILE_TYPE_HTTPCLASS = EnumItem.new('PROFILE_TYPE_HTTPCLASS', '16')
 
         # The DNS profile.
-        PROFILE_TYPE_DNS = 17
+        PROFILE_TYPE_DNS = EnumItem.new('PROFILE_TYPE_DNS', '17')
 
         # The SCTP profile.
-        PROFILE_TYPE_SCTP = 18
+        PROFILE_TYPE_SCTP = EnumItem.new('PROFILE_TYPE_SCTP', '18')
 
         # A loosely-typed profile.
-        PROFILE_TYPE_INSTANCE = 19
+        PROFILE_TYPE_INSTANCE = EnumItem.new('PROFILE_TYPE_INSTANCE', '19')
 
         # The SIP profile.
-        PROFILE_TYPE_SIPP = 20
+        PROFILE_TYPE_SIPP = EnumItem.new('PROFILE_TYPE_SIPP', '20')
 
         # The HTTP Compression profile.
-        PROFILE_TYPE_HTTPCOMPRESSION = 21
+        PROFILE_TYPE_HTTPCOMPRESSION = EnumItem.new('PROFILE_TYPE_HTTPCOMPRESSION', '21')
 
         # The Web Acceleration profile.
-        PROFILE_TYPE_WEBACCELERATION = 22
+        PROFILE_TYPE_WEBACCELERATION = EnumItem.new('PROFILE_TYPE_WEBACCELERATION', '22')
 
         # Profile type is unknown (or is unsupported by iControl).
-        PROFILE_TYPE_UNKNOWN = 23
+        PROFILE_TYPE_UNKNOWN = EnumItem.new('PROFILE_TYPE_UNKNOWN', '23')
 
         # The RADIUS profile.
-        PROFILE_TYPE_RADIUS = 24
+        PROFILE_TYPE_RADIUS = EnumItem.new('PROFILE_TYPE_RADIUS', '24')
 
         # The Diameter profile.
-        PROFILE_TYPE_DIAMETER = 25
+        PROFILE_TYPE_DIAMETER = EnumItem.new('PROFILE_TYPE_DIAMETER', '25')
       end
     end
   end

--- a/lib/f5/icontrol/locallb/server_ssl_certificate_mode.rb
+++ b/lib/f5/icontrol/locallb/server_ssl_certificate_mode.rb
@@ -1,0 +1,17 @@
+require 'f5/icontrol/common/enum_item'
+
+module F5
+  module Icontrol
+    module LocalLB
+      # https://devcentral.f5.com/wiki/iControl.LocalLB__ServerSSLCertificateMode.ashx
+      # A list of server-side SSL certificate modes.
+      module ServerSSLCertificateMode
+        # The certificate is required.
+        SERVERSSL_CERTIFICATE_MODE_REQUIRE = EnumItem.new('SERVERSSL_CERTIFICATE_MODE_REQUIRE', '0')
+
+        # The certificate is ignored.
+        SERVERSSL_CERTIFICATE_MODE_IGNORE = EnumItem.new('SERVERSSL_CERTIFICATE_MODE_IGNORE', '1')
+      end
+    end
+  end
+end

--- a/lib/f5/icontrol/locallb/virtual_server/source_address_translation.rb
+++ b/lib/f5/icontrol/locallb/virtual_server/source_address_translation.rb
@@ -1,3 +1,5 @@
+require 'f5/icontrol/common/enum_item'
+
 module F5
   module Icontrol
     module LocalLB
@@ -6,19 +8,19 @@ module F5
         # A list of source address translation types.
         module SourceAddressTranslationType
           # Translation type unknown (or unsupported by iControl).
-          SRC_TRANS_UNKNOWN = 0 
+          SRC_TRANS_UNKNOWN = EnumItem.new('SRC_TRANS_UNKNOWN', '0')
 
           # No translation is being used.
-          SRC_TRANS_NONE = 1
+          SRC_TRANS_NONE = EnumItem.new('SRC_TRANS_NONE', '1')
 
           # The translation uses self IP addresses.
-          SRC_TRANS_AUTOMAP = 2
+          SRC_TRANS_AUTOMAP = EnumItem.new('SRC_TRANS_AUTOMAP', '2')
 
           # The translation uses a SNAT pool of translation addresses.
-          SRC_TRANS_SNATPOOL = 3
+          SRC_TRANS_SNATPOOL = EnumItem.new('SRC_TRANS_SNATPOOL', '3')
 
           # The translation uses an LSN pool of translation addresses.
-          SRC_TRANS_LSNPOOL = 4
+          SRC_TRANS_LSNPOOL = EnumItem.new('SRC_TRANS_LSNPOOL', '4')
         end
       end
     end


### PR DESCRIPTION
Field testing reveals that while the F5 docs imply they might work with the _value_ property of enumerations they actually expect and return the _member_ property.

### API Logging

Discovering and debugging this required enabling logging in the underlying Savon library.

This PR introduces three new options when creating an `F5::Icontrol::API` client:
```
api = F5::Icontrol::API.new(
    host: "hostname.of.bigip",
    username: "username",
    password: "password",

    # Savon logging options
    enable_logging: true,   # defaults to: false
    log_level: :debug,      # defaults to: debug
    pretty_print_xml: true, # defaults to: true
)
```
which are passed to the underlying Savon SOAP client.

### Handling Enumerations

This PR introduces (and refactors existing enumerations to make use of) a custom EnumItem type:
```
EnumItem = Struct.new(:member, :value) do
  def to_s
    self.member
  end

  def to_i
    self.value
  end
end
```
so that we can define enumerations like this:
```
require 'f5/icontrol/common/enum_item'

module F5
  module Icontrol
    module Common
      module EnabledState
        STATE_DISABLED = EnumItem.new('STATE_DISABLED', 0)
        STATE_ENABLED  = EnumItem.new('STATE_ENABLED', 1)
      end
    end
  end
end
```
and use them like this:
```
    enabled_state = F5::Icontrol::Common::EnabledState
    
   api.LocalLB.NodeAddressV2.set_session_enabled_state({
      nodes: { item: ['mynode'] },
      states: { item: [enabled_state::STATE_ENABLED] }
      })
```
and Savon will serialize them using the `.to_s` (which maps to `.member`) like so:
```
<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:iControl:LocalLB/NodeAddressV2" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ins0="urn:iControl">
  <env:Body>
    <tns:set_session_enabled_state>
      <nodes>
        <item>mynode</item>
      </nodes>
      <states>
        <item>STATE_ENABLED</item>
      </states>
    </tns:set_session_enabled_state>
  </env:Body>
</env:Envelope>
```
