### PR TITLE
embed additional requires into top-level module definition

### DIFF
--- a/lib/f5/icontrol.rb
+++ b/lib/f5/icontrol.rb
@@ -1,5 +1,14 @@
 require "f5/icontrol/version"
 require "f5/icontrol/api"
+require 'f5/icontrol/common/enabled_state'
+require 'f5/icontrol/common/enum_item'
+require 'f5/icontrol/locallb/virtual_server/source_address_translation'
+require 'f5/icontrol/locallb/availability_status'
+require 'f5/icontrol/locallb/client_ssl_certificate_mode'
+require 'f5/icontrol/locallb/enabled_status'
+require 'f5/icontrol/locallb/profile_context_type'
+require 'f5/icontrol/locallb/profile_type'
+require 'f5/icontrol/locallb/server_ssl_certificate_mode'
 require "openssl"
 require "savon"
 


### PR DESCRIPTION
this appears to be an established pattern in ruby gems which I just learned; by adding all these require statements into the top-level `f5/icontrol` module consumers can simply `require 'f5/icontrol'` and import all the pre-referenced goodness.