### PR TITLE
preserve underscores in pool names

### DIFF
--- a/lib/f5/icontrol/rapi.rb
+++ b/lib/f5/icontrol/rapi.rb
@@ -63,7 +63,9 @@ module F5
 
       private
       def url
-        method_chain = @method_chain.gsub /_/, '-'
+        pool_match = @method_chain.match %r{(/pool/[A-Za-z0-9\-_~]+)}
+        method_chain = @method_chain.tr '_', '-'
+        method_chain = method_chain.sub %r{/pool/[A-Za-z0-9\-_~]+}, pool_match[1] unless pool_match.nil?
         method_chain.gsub! %r{^/}, ''
         "https://#{@args[:host]}/#{method_chain}"
       end

--- a/spec/models/rapi_spec.rb
+++ b/spec/models/rapi_spec.rb
@@ -40,6 +40,15 @@ describe F5::Icontrol::RAPI do
         expect(WebMock).to have_requested(:get, "#{baseurl}/foo-bar/")
       end
 
+      it "preserves underscores in pool names" do
+        stub_request(:get, "#{baseurl}/pool/foo_bar").
+          to_return(body: pool_collection)
+
+        subject.pool.load('foo_bar')
+
+        expect(WebMock).to have_requested(:get, "#{baseurl}/pool/foo_bar")
+      end
+
       it "understands `each` implicitly calls `get_collection`" do
         stub_request(:get, "#{baseurl}/foo/bar/").
           to_return(body: pool_collection)


### PR DESCRIPTION
Puts the original pool name back in a REST URL after replacing all the underscores
to prevent them from being mutated in the final call.

Fixes #20